### PR TITLE
Broaden expected max time from 2s to 3

### DIFF
--- a/tests/test_cloud_watch/cloudwatch/test_cloudwatch_publish.py
+++ b/tests/test_cloud_watch/cloudwatch/test_cloudwatch_publish.py
@@ -51,7 +51,7 @@ def test_publish_time(
     # AWS timestamps do not have microseconds, so we'll floor the time to the nearest second
     # We cant get the time exactly, but a leeway of 3 seconds should do, even if floored
     current_time = datetime.now(timezone.utc).replace(microsecond=0)
-    expected_max_time = (datetime.now(timezone.utc) + timedelta(seconds=2)).replace(
+    expected_max_time = (datetime.now(timezone.utc) + timedelta(seconds=3)).replace(
         microsecond=0
     )
     # Publish the metric


### PR DESCRIPTION
- cloudwatch metric test for time had too little a max time, which caused failure on testing sometimes even though all is well. broadened the max time