### PR TITLE
Base-api-tests

### DIFF
--- a/tests/switcheroo/base/__init__.py
+++ b/tests/switcheroo/base/__init__.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 import uuid
 import json
 from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.description import Description
 from switcheroo.base.data_store import Serializer
 
 
@@ -41,8 +42,15 @@ class PersonSerializer(Serializer[Person]):
         return Person(data_obj["name"], data_obj["age"], data_obj["bio"], data_obj["unique_id"])
 
 class HasFileMode(BaseMatcher[Path]):
-
+    """Hamcrest matcher to check the file mode of a given pathlib.Path
+    """
     def __init__(self, file_mode: int) -> None:
+        """Creates the matcher
+
+        Args:
+            file_mode (int): the file mode to check for - the check treats the int as a \
+            octal value - ie if 755 is passed in, the matcher looks for the permission 0o755
+        """
         super().__init__()
         self._file_mode = file_mode
 
@@ -50,3 +58,7 @@ class HasFileMode(BaseMatcher[Path]):
         file_mode_str = oct(item.stat().st_mode) #Returns 0o100[mode] as a str
         file_mode = int(file_mode_str[5:]) #Get just [mode]
         return file_mode == self._file_mode
+
+    def describe_to(self, description: Description) -> None:
+        description.append_text(f"File mode which is {self._file_mode} in octal") \
+                   .append_text(f"(0o{self._file_mode})")

--- a/tests/switcheroo/base/__init__.py
+++ b/tests/switcheroo/base/__init__.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from dataclasses import dataclass, field
+import uuid
+import json
+from hamcrest.core.base_matcher import BaseMatcher
+from switcheroo.base.data_store import Serializer
+
+
+def _str_uuid_factory():
+    return str(uuid.uuid4())
+
+@dataclass
+class Person:
+    """Dataclass representing a person to be used for testing
+    """
+    name: str
+    age: int
+    bio: str
+    #Storing uuid as a string for easy json serialization
+    unique_id: str = field(default_factory=_str_uuid_factory)
+
+    @property
+    def relative_loc(self)->Path:
+        """Relative location of a person in a storage system
+
+
+        Returns:
+            Path: Relative location of this person in a storage system as a pathlib.Path obj
+        """
+        return Path(self.unique_id)
+
+class PersonSerializer(Serializer[Person]):
+    """Serializer for the Person class - just to/from json
+    """
+
+    def serialize(self, storable: Person) -> str:
+        return json.dumps(storable.__dict__)
+
+    def deserialize(self, data_str: str) -> Person:
+        data_obj =  json.loads(data_str)
+        return Person(data_obj["name"], data_obj["age"], data_obj["bio"], data_obj["unique_id"])
+
+class HasFileMode(BaseMatcher[Path]):
+
+    def __init__(self, file_mode: int) -> None:
+        super().__init__()
+        self._file_mode = file_mode
+
+    def _matches(self, item: Path) -> bool:
+        file_mode_str = oct(item.stat().st_mode) #Returns 0o100[mode] as a str
+        file_mode = int(file_mode_str[5:]) #Get just [mode]
+        return file_mode == self._file_mode

--- a/tests/switcheroo/base/__init__.py
+++ b/tests/switcheroo/base/__init__.py
@@ -1,45 +1,6 @@
 from pathlib import Path
-from dataclasses import dataclass, field
-import uuid
-import json
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.description import Description
-from switcheroo.base.data_store import Serializer
-
-
-def _str_uuid_factory():
-    return str(uuid.uuid4())
-
-@dataclass
-class Person:
-    """Dataclass representing a person to be used for testing
-    """
-    name: str
-    age: int
-    bio: str
-    #Storing uuid as a string for easy json serialization
-    unique_id: str = field(default_factory=_str_uuid_factory)
-
-    @property
-    def relative_loc(self)->Path:
-        """Relative location of a person in a storage system
-
-
-        Returns:
-            Path: Relative location of this person in a storage system as a pathlib.Path obj
-        """
-        return Path(self.unique_id)
-
-class PersonSerializer(Serializer[Person]):
-    """Serializer for the Person class - just to/from json
-    """
-
-    def serialize(self, storable: Person) -> str:
-        return json.dumps(storable.__dict__)
-
-    def deserialize(self, data_str: str) -> Person:
-        data_obj =  json.loads(data_str)
-        return Person(data_obj["name"], data_obj["age"], data_obj["bio"], data_obj["unique_id"])
 
 class HasFileMode(BaseMatcher[Path]):
     """Hamcrest matcher to check the file mode of a given pathlib.Path

--- a/tests/switcheroo/base/conftest.py
+++ b/tests/switcheroo/base/conftest.py
@@ -5,31 +5,45 @@ import random
 import json
 import uuid
 import pytest
+from mypy_boto3_s3 import S3Client
 from switcheroo.base.data_store import FileDataStore
+from switcheroo.base.data_store.s3 import S3DataStore
 from tests.switcheroo.base.resources import Person, PersonSerializer, Figure
 
 
 @pytest.fixture(name="tmp_pathlib_dir")
-def fixture_tmp_pathlib_dir()->Generator[Path, None, None]:
+def fixture_tmp_pathlib_dir() -> Generator[Path, None, None]:
     temp_dir = TemporaryDirectory()
     with temp_dir:
         yield Path(temp_dir.name)
 
-@pytest.fixture(name="file_datastore")
-def fixture_file_datastore(tmp_pathlib_dir: Path)->FileDataStore: #Standard pytest tmpdir fixture
+
+@pytest.fixture
+def file_datastore(
+    tmp_pathlib_dir: Path,
+) -> FileDataStore:  # Standard pytest tmpdir fixture
     file_ds = FileDataStore(FileDataStore.RootInfo(tmp_pathlib_dir))
     file_ds.register_serializer(Person, PersonSerializer())
     return file_ds
 
-#Utility fixtures for the Person dataclass
+
+@pytest.fixture
+def s3_datastore(s3_bucket: str) -> S3DataStore:
+    s3_ds = S3DataStore(s3_bucket)
+    s3_ds.register_serializer(Person, PersonSerializer())
+    return s3_ds
+
+
+# Utility fixtures for the Person dataclass
 
 PersonGenerator: TypeAlias = Callable[[], Person]
 PersonLocator: TypeAlias = Callable[[Person], Path]
 PersonReader: TypeAlias = Callable[[Person], Person]
 PersonPublisher: TypeAlias = Callable[[Person], None]
 
+
 @pytest.fixture(name="person_locator")
-def fixture_person_locator(tmp_pathlib_dir: Path)->PersonLocator:
+def fixture_person_locator(tmp_pathlib_dir: Path) -> PersonLocator:
     """Fixture to locate the absolute Path of where a Person is stored using the FileDataStore
 
     Args:
@@ -38,12 +52,22 @@ def fixture_person_locator(tmp_pathlib_dir: Path)->PersonLocator:
     Returns:
         PersonLocator: A function to locate the absolute path of a Person
     """
-    def _locate_person(person: Person)->Path:
-        return tmp_pathlib_dir/person.relative_loc
+
+    def _locate_person(person: Person) -> Path:
+        return tmp_pathlib_dir / person.relative_loc
+
     return _locate_person
 
+
+def _json_to_person(data_str: str) -> Person:
+    data_obj = json.loads(data_str)
+    return Person(
+        data_obj["unique_id"], data_obj["name"], data_obj["age"], data_obj["bio"]
+    )
+
+
 @pytest.fixture
-def read_person_from_file(person_locator: PersonLocator)->PersonReader:
+def read_person_from_file(person_locator: PersonLocator) -> PersonReader:
     """Reads a person from a file based on their expected location via the given PersonLocator
 
     Args:
@@ -52,60 +76,94 @@ def read_person_from_file(person_locator: PersonLocator)->PersonReader:
     Returns:
         PersonReader: A function to read a person from their expected location
     """
-    def _read_person_from_file(person: Person)->Person:
+
+    def _read_person_from_file(person: Person) -> Person:
         person_location = person_locator(person)
         with open(person_location, mode="rt", encoding="utf-8") as person_data:
-            data_obj = json.load(person_data)
-            return Person(data_obj["unique_id"], data_obj["name"], data_obj["age"], data_obj["bio"])
+            return _json_to_person(person_data.read())
+
     return _read_person_from_file
 
+
 @pytest.fixture
-def publish_person_to_file(person_locator: PersonLocator)->PersonPublisher:
+def read_person_from_s3(s3_bucket: str, s3_client: S3Client) -> PersonReader:
+    def _read_person_from_s3(person: Person) -> Person:
+        file = s3_client.get_object(Bucket=s3_bucket, Key=str(person.relative_loc))
+        file_data = file["Body"].read()
+        contents = file_data.decode("utf-8")
+        return _json_to_person(contents)
+
+    return _read_person_from_s3
+
+
+@pytest.fixture
+def publish_person_to_file(person_locator: PersonLocator) -> PersonPublisher:
     def _publish_person_to_file(person: Person):
         person_location = person_locator(person)
         with open(person_location, mode="wt", encoding="utf-8") as person_data:
             json.dump(person.__dict__, person_data)
+
     return _publish_person_to_file
 
+
+@pytest.fixture
+def publish_person_to_s3(s3_bucket: str, s3_client: S3Client) -> PersonPublisher:
+    def _publish_person_to_s3(person: Person):
+        s3_client.put_object(
+            Bucket=s3_bucket,
+            Key=str(person.relative_loc),
+            Body=json.dumps(person.__dict__),
+        )
+
+    return _publish_person_to_s3
+
+
 @pytest.fixture(scope="session", name="person_generator")
-def fixture_person_generator()->PersonGenerator:
-    names = ["Reuven","Shimon","Levi","Yehuda","Yissachar","Zevulun"]
-    colors = ["red","yellow","orange","green","blue","purple"]
-    def _person_generator()->Person:
+def fixture_person_generator() -> PersonGenerator:
+    names = ["Reuven", "Shimon", "Levi", "Yehuda", "Yissachar", "Zevulun"]
+    colors = ["red", "yellow", "orange", "green", "blue", "purple"]
+
+    def _person_generator() -> Person:
         unique_id = str(uuid.uuid4())
         name = random.choice(names)
         color = random.choice(colors)
-        age = random.randint(1,120)
+        age = random.randint(1, 120)
         return Person(unique_id, name, age, f"{name} really likes the color {color}")
+
     return _person_generator
 
+
 @pytest.fixture
-def rand_person(person_generator: PersonGenerator)->Person:
+def rand_person(person_generator: PersonGenerator) -> Person:
     return person_generator()
 
-#Utility fixtures for the Figure dataclass
-#Very similar to the Person one
+
+# Utility fixtures for the Figure dataclass
+# Very similar to the Person one
 FigureGenerator: TypeAlias = Callable[[], Figure]
 # FigureLocator: TypeAlias = Callable[[Figure], Path]
 # FigureReader: TypeAlias = Callable[[Figure], Figure]
 # FigurePublisher: TypeAlias = Callable[[Figure], None]
 
+
 @pytest.fixture(scope="session", name="figure_generator")
-def fixture_figure_generator()->FigureGenerator:
-    shapes = ["Square","Circle","Triangle"]
-    colors = ["red","yellow","orange","green","blue","purple"]
-    def _figure_generator()->Figure:
+def fixture_figure_generator() -> FigureGenerator:
+    shapes = ["Square", "Circle", "Triangle"]
+    colors = ["red", "yellow", "orange", "green", "blue", "purple"]
+
+    def _figure_generator() -> Figure:
         unique_id = str(uuid.uuid4())
         shape = random.choice(shapes)
         color = random.choice(colors)
-        size = random.randint(1,1000)
+        size = random.randint(1, 1000)
         return Figure(unique_id, shape, color, size)
+
     return _figure_generator
 
-@pytest.fixture
-def rand_figure(figure_generator: FigureGenerator)->Figure:
-    return figure_generator()
 
+@pytest.fixture
+def rand_figure(figure_generator: FigureGenerator) -> Figure:
+    return figure_generator()
 
 
 # @pytest.fixture(name="figure_locator")
@@ -136,7 +194,8 @@ def rand_figure(figure_generator: FigureGenerator)->Figure:
 #         figure_location = figure_locator(figure)
 #         with open(figure_location, mode="rt", encoding="utf-8") as person_data:
 #             data_ob = json.load(person_data)
-#             return Figure(data_ob["unique_id"], data_ob["shape"], data_ob["color"], data_ob["size"])
+#             return Figure(data_ob["unique_id"], data_ob["shape"],
+#                           data_ob["color"], data_ob["size"])
 #     return _read_person_from_file
 
 # @pytest.fixture

--- a/tests/switcheroo/base/conftest.py
+++ b/tests/switcheroo/base/conftest.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from typing import Callable, TypeAlias, Generator
+from tempfile import TemporaryDirectory
+import random
+import json
+import pytest
+from switcheroo.base.data_store import FileDataStore
+from tests.switcheroo.base import Person, PersonSerializer
+
+PersonGenerator: TypeAlias = Callable[[], Person]
+PersonLocator: TypeAlias = Callable[[Person], Path]
+PersonReader: TypeAlias = Callable[[Person], Person]
+PersonPublisher: TypeAlias = Callable[[Person], None]
+
+@pytest.fixture(name="tmp_pathlib_dir")
+def fixture_tmp_pathlib_dir()->Generator[Path, None, None]:
+    temp_dir = TemporaryDirectory()
+    with temp_dir:
+        yield Path(temp_dir.name)
+
+@pytest.fixture(name="file_datastore")
+def fixture_file_datastore(tmp_pathlib_dir: Path)->FileDataStore: #Standard pytest tmpdir fixture
+    file_ds = FileDataStore(FileDataStore.RootInfo(tmp_pathlib_dir))
+    file_ds.register_serializer(Person, PersonSerializer())
+    return file_ds
+
+@pytest.fixture(name="person_locator")
+def fixture_person_locator(tmp_pathlib_dir: Path)->PersonLocator:
+    """Fixture to locate the absolute Path of where a Person is stored using the FileDataStore
+
+    Args:
+        tmpdir (Path): standard pytest tmpdir fixture - root location for storage
+
+    Returns:
+        PersonLocator: A function to locate the absolute path of a Person
+    """
+    def _locate_person(person: Person)->Path:
+        return tmp_pathlib_dir/person.relative_loc
+    return _locate_person
+
+@pytest.fixture
+def read_person_from_file(person_locator: PersonLocator)->PersonReader:
+    """Reads a person from a file based on their expected location via the given PersonLocator
+
+    Args:
+        person_locator (PersonLocator): Used to give the absolute path for a Person
+
+    Returns:
+        PersonReader: A function to read a person from their expected location
+    """
+    def _read_person_from_file(person: Person)->Person:
+        person_location = person_locator(person)
+        with open(person_location, mode="rt", encoding="utf-8") as person_data:
+            data_obj = json.load(person_data)
+            return Person(data_obj["name"], data_obj["age"], data_obj["bio"], data_obj["unique_id"])
+    return _read_person_from_file
+
+@pytest.fixture
+def publish_person_to_file(person_locator: PersonLocator)->PersonPublisher:
+    def _publish_person_to_file(person: Person):
+        person_location = person_locator(person)
+        with open(person_location, mode="wt", encoding="utf-8") as person_data:
+            json.dump(person.__dict__, person_data)
+    return _publish_person_to_file
+
+@pytest.fixture(scope="session")
+def person_generator()->PersonGenerator:
+    names = ["Reuven","Shimon","Levi","Yehuda","Yissachar","Zevulun"]
+    colors = ["red","yellow","orange","green","blue","purple"]
+    def _person_generator()->Person:
+        name = random.choice(names)
+        color = random.choice(colors)
+        age = random.randint(1,120)
+        return Person(name, age, f"{name} really likes the color {color}")
+    return _person_generator

--- a/tests/switcheroo/base/conftest.py
+++ b/tests/switcheroo/base/conftest.py
@@ -3,14 +3,11 @@ from typing import Callable, TypeAlias, Generator
 from tempfile import TemporaryDirectory
 import random
 import json
+import uuid
 import pytest
 from switcheroo.base.data_store import FileDataStore
-from tests.switcheroo.base import Person, PersonSerializer
+from tests.switcheroo.base.resources import Person, PersonSerializer, Figure
 
-PersonGenerator: TypeAlias = Callable[[], Person]
-PersonLocator: TypeAlias = Callable[[Person], Path]
-PersonReader: TypeAlias = Callable[[Person], Person]
-PersonPublisher: TypeAlias = Callable[[Person], None]
 
 @pytest.fixture(name="tmp_pathlib_dir")
 def fixture_tmp_pathlib_dir()->Generator[Path, None, None]:
@@ -23,6 +20,13 @@ def fixture_file_datastore(tmp_pathlib_dir: Path)->FileDataStore: #Standard pyte
     file_ds = FileDataStore(FileDataStore.RootInfo(tmp_pathlib_dir))
     file_ds.register_serializer(Person, PersonSerializer())
     return file_ds
+
+#Utility fixtures for the Person dataclass
+
+PersonGenerator: TypeAlias = Callable[[], Person]
+PersonLocator: TypeAlias = Callable[[Person], Path]
+PersonReader: TypeAlias = Callable[[Person], Person]
+PersonPublisher: TypeAlias = Callable[[Person], None]
 
 @pytest.fixture(name="person_locator")
 def fixture_person_locator(tmp_pathlib_dir: Path)->PersonLocator:
@@ -52,7 +56,7 @@ def read_person_from_file(person_locator: PersonLocator)->PersonReader:
         person_location = person_locator(person)
         with open(person_location, mode="rt", encoding="utf-8") as person_data:
             data_obj = json.load(person_data)
-            return Person(data_obj["name"], data_obj["age"], data_obj["bio"], data_obj["unique_id"])
+            return Person(data_obj["unique_id"], data_obj["name"], data_obj["age"], data_obj["bio"])
     return _read_person_from_file
 
 @pytest.fixture
@@ -63,13 +67,82 @@ def publish_person_to_file(person_locator: PersonLocator)->PersonPublisher:
             json.dump(person.__dict__, person_data)
     return _publish_person_to_file
 
-@pytest.fixture(scope="session")
-def person_generator()->PersonGenerator:
+@pytest.fixture(scope="session", name="person_generator")
+def fixture_person_generator()->PersonGenerator:
     names = ["Reuven","Shimon","Levi","Yehuda","Yissachar","Zevulun"]
     colors = ["red","yellow","orange","green","blue","purple"]
     def _person_generator()->Person:
+        unique_id = str(uuid.uuid4())
         name = random.choice(names)
         color = random.choice(colors)
         age = random.randint(1,120)
-        return Person(name, age, f"{name} really likes the color {color}")
+        return Person(unique_id, name, age, f"{name} really likes the color {color}")
     return _person_generator
+
+@pytest.fixture
+def rand_person(person_generator: PersonGenerator)->Person:
+    return person_generator()
+
+#Utility fixtures for the Figure dataclass
+#Very similar to the Person one
+FigureGenerator: TypeAlias = Callable[[], Figure]
+# FigureLocator: TypeAlias = Callable[[Figure], Path]
+# FigureReader: TypeAlias = Callable[[Figure], Figure]
+# FigurePublisher: TypeAlias = Callable[[Figure], None]
+
+@pytest.fixture(scope="session", name="figure_generator")
+def fixture_figure_generator()->FigureGenerator:
+    shapes = ["Square","Circle","Triangle"]
+    colors = ["red","yellow","orange","green","blue","purple"]
+    def _figure_generator()->Figure:
+        unique_id = str(uuid.uuid4())
+        shape = random.choice(shapes)
+        color = random.choice(colors)
+        size = random.randint(1,1000)
+        return Figure(unique_id, shape, color, size)
+    return _figure_generator
+
+@pytest.fixture
+def rand_figure(figure_generator: FigureGenerator)->Figure:
+    return figure_generator()
+
+
+
+# @pytest.fixture(name="figure_locator")
+# def fixture_figure_locator(tmp_pathlib_dir: Path)->FigureLocator:
+#     """Fixture to locate the absolute Path of where a Figure is stored using the FileDataStore
+
+#     Args:
+#         tmpdir (Path): standard pytest tmpdir fixture - root location for storage
+
+#     Returns:
+#         FigureLocator: A function to locate the absolute path of a Figure
+#     """
+#     def _locate_figure(figure: Figure)->Path:
+#         return tmp_pathlib_dir/figure.relative_loc
+#     return _locate_figure
+
+# @pytest.fixture
+# def read_figure_from_file(figure_locator: FigureLocator)->FigureReader:
+#     """Reads a figure from a file based on their expected location via the given FigureLocator
+
+#     Args:
+#         figure_locator (PersonLocator): Used to give the absolute path for a Figure
+
+#     Returns:
+#         FigureReader: A function to read a figure from their expected location
+#     """
+#     def _read_person_from_file(figure: Figure)->Figure:
+#         figure_location = figure_locator(figure)
+#         with open(figure_location, mode="rt", encoding="utf-8") as person_data:
+#             data_ob = json.load(person_data)
+#             return Figure(data_ob["unique_id"], data_ob["shape"], data_ob["color"], data_ob["size"])
+#     return _read_person_from_file
+
+# @pytest.fixture
+# def publish_figure_to_file(figure_locator: FigureLocator)->FigurePublisher:
+#     def _publish_figure_to_file(figure: Figure):
+#         figure_location = figure_locator(figure)
+#         with open(figure_location, mode="wt", encoding="utf-8") as figure_data:
+#             json.dump(figure.__dict__, figure_data)
+#     return _publish_figure_to_file

--- a/tests/switcheroo/base/resources/__init__.py
+++ b/tests/switcheroo/base/resources/__init__.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from dataclasses import dataclass
+from abc import ABC
+import json
+from switcheroo.base.data_store import Serializer
+
+
+@dataclass
+class Storable(ABC):
+    #Storing uuid as a string for easy json serialization
+    unique_id: str
+
+    @property
+    def relative_loc(self)->Path:
+        """Relative location of a person in a storage system
+
+
+        Returns:
+            Path: Relative location of this person in a storage system as a pathlib.Path obj
+        """
+        return Path(self.unique_id)
+
+@dataclass
+class Person(Storable):
+    """Dataclass representing a person to be used for testing
+    """
+    name: str
+    age: int
+    bio: str
+
+@dataclass
+class Figure(Storable):
+    shape: str
+    color: str
+    size: int
+
+
+
+class PersonSerializer(Serializer[Person]):
+    """Serializer for the Person class - just to/from json
+    """
+
+    def serialize(self, storable: Person) -> str:
+        return json.dumps(storable.__dict__)
+
+    def deserialize(self, data_str: str) -> Person:
+        data_obj =  json.loads(data_str)
+        return Person(data_obj["unique_id"], data_obj["name"], data_obj["age"], data_obj["bio"])
+
+class FigureSerializer(Serializer[Figure]):
+    """Serializer for the Figure class - just to/from json
+    """
+    def serialize(self, storable: Figure) -> str:
+        return json.dumps(storable.__dict__)
+
+    def deserialize(self, data_str: str) -> Figure:
+        data_obj = json.loads(data_str)
+        return Figure(data_obj["unique_id"], data_obj["shape"], data_obj["color"], data_obj["size"])

--- a/tests/switcheroo/base/resources/module1.py
+++ b/tests/switcheroo/base/resources/module1.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from switcheroo.base import Serializer
+
+@dataclass
+class SomeClass:
+    value: str
+
+class SomeClassSerializer(Serializer[SomeClass]):
+
+    def serialize(self, storable: SomeClass) -> str:
+        return storable.value
+
+    def deserialize(self, data_str: str) -> SomeClass:
+        return SomeClass(data_str)

--- a/tests/switcheroo/base/resources/module2.py
+++ b/tests/switcheroo/base/resources/module2.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from switcheroo.base import Serializer
+
+@dataclass
+class SomeClass:
+    value: str
+
+class SomeClassSerializer(Serializer[SomeClass]):
+
+    def serialize(self, storable: SomeClass) -> str:
+        return storable.value
+
+    def deserialize(self, data_str: str) -> SomeClass:
+        return SomeClass(data_str)

--- a/tests/switcheroo/base/test_common_datastore.py
+++ b/tests/switcheroo/base/test_common_datastore.py
@@ -4,26 +4,28 @@ This module utilizes the FileDataStore because it is the simplest one to use
 from pathlib import Path
 from hamcrest import assert_that, equal_to
 from tests.switcheroo.base.resources import Person, Figure, FigureSerializer
-import tests.switcheroo.base.resources.module1 as module1
-import tests.switcheroo.base.resources.module2 as module2
+import tests.switcheroo.base.resources.module1 as module1  # pylint: disable="consider-using-from-import"
+import tests.switcheroo.base.resources.module2 as module2  # pylint: disable="consider-using-from-import"
 from switcheroo.base.data_store import FileDataStore
 
-def test_ds_can_handle_different_classes(file_datastore: FileDataStore,
-                                         rand_person: Person,
-                                         rand_figure: Figure):
-    file_datastore.register_serializer(Figure, FigureSerializer())
-    file_datastore.publish(rand_person, rand_person.relative_loc)
-    file_datastore.publish(rand_figure, rand_figure.relative_loc)
 
-    read_figure = file_datastore.retrieve(rand_figure.relative_loc, Figure)
-    read_person = file_datastore.retrieve(rand_person.relative_loc, Person)
+def test_ds_can_handle_different_classes(
+    s3_datastore: FileDataStore, rand_person: Person, rand_figure: Figure
+):
+    s3_datastore.register_serializer(Figure, FigureSerializer())
+    s3_datastore.publish(rand_person, rand_person.relative_loc)
+    s3_datastore.publish(rand_figure, rand_figure.relative_loc)
+
+    read_figure = s3_datastore.retrieve(rand_figure.relative_loc, Figure)
+    read_person = s3_datastore.retrieve(rand_person.relative_loc, Person)
 
     assert_that(read_figure, equal_to(rand_figure))
     assert_that(read_person, equal_to(rand_person))
 
-def test_ds_can_handle_diff_modules_same_class_name(file_datastore: FileDataStore):
-    file_datastore.register_serializer(module1.SomeClass, module1.SomeClassSerializer())
-    file_datastore.register_serializer(module2.SomeClass, module2.SomeClassSerializer())
+
+def test_ds_can_handle_diff_modules_same_class_name(s3_datastore: FileDataStore):
+    s3_datastore.register_serializer(module1.SomeClass, module1.SomeClassSerializer())
+    s3_datastore.register_serializer(module2.SomeClass, module2.SomeClassSerializer())
 
     mod1_loc = Path("mod1")
     mod2_loc = Path("mod2")
@@ -31,11 +33,11 @@ def test_ds_can_handle_diff_modules_same_class_name(file_datastore: FileDataStor
     mod1 = module1.SomeClass("Module1")
     mod2 = module2.SomeClass("Module2")
 
-    file_datastore.publish(mod1, mod1_loc)
-    file_datastore.publish(mod2, mod2_loc)
+    s3_datastore.publish(mod1, mod1_loc)
+    s3_datastore.publish(mod2, mod2_loc)
 
-    retrieved_mod1 = file_datastore.retrieve(mod1_loc, module1.SomeClass)
-    retrieved_mod2 = file_datastore.retrieve(mod2_loc, module2.SomeClass)
+    retrieved_mod1 = s3_datastore.retrieve(mod1_loc, module1.SomeClass)
+    retrieved_mod2 = s3_datastore.retrieve(mod2_loc, module2.SomeClass)
     assert retrieved_mod1 is not None
     assert retrieved_mod2 is not None
     assert_that(retrieved_mod1.value, equal_to(mod1.value))

--- a/tests/switcheroo/base/test_common_datastore.py
+++ b/tests/switcheroo/base/test_common_datastore.py
@@ -1,0 +1,42 @@
+"""This module tests the features common to the abstract DataStore class.
+This module utilizes the FileDataStore because it is the simplest one to use
+"""
+from pathlib import Path
+from hamcrest import assert_that, equal_to
+from tests.switcheroo.base.resources import Person, Figure, FigureSerializer
+import tests.switcheroo.base.resources.module1 as module1
+import tests.switcheroo.base.resources.module2 as module2
+from switcheroo.base.data_store import FileDataStore
+
+def test_ds_can_handle_different_classes(file_datastore: FileDataStore,
+                                         rand_person: Person,
+                                         rand_figure: Figure):
+    file_datastore.register_serializer(Figure, FigureSerializer())
+    file_datastore.publish(rand_person, rand_person.relative_loc)
+    file_datastore.publish(rand_figure, rand_figure.relative_loc)
+
+    read_figure = file_datastore.retrieve(rand_figure.relative_loc, Figure)
+    read_person = file_datastore.retrieve(rand_person.relative_loc, Person)
+
+    assert_that(read_figure, equal_to(rand_figure))
+    assert_that(read_person, equal_to(rand_person))
+
+def test_ds_can_handle_diff_modules_same_class_name(file_datastore: FileDataStore):
+    file_datastore.register_serializer(module1.SomeClass, module1.SomeClassSerializer())
+    file_datastore.register_serializer(module2.SomeClass, module2.SomeClassSerializer())
+
+    mod1_loc = Path("mod1")
+    mod2_loc = Path("mod2")
+
+    mod1 = module1.SomeClass("Module1")
+    mod2 = module2.SomeClass("Module2")
+
+    file_datastore.publish(mod1, mod1_loc)
+    file_datastore.publish(mod2, mod2_loc)
+
+    retrieved_mod1 = file_datastore.retrieve(mod1_loc, module1.SomeClass)
+    retrieved_mod2 = file_datastore.retrieve(mod2_loc, module2.SomeClass)
+    assert retrieved_mod1 is not None
+    assert retrieved_mod2 is not None
+    assert_that(retrieved_mod1.value, equal_to(mod1.value))
+    assert_that(retrieved_mod2.value, equal_to(mod2.value))

--- a/tests/switcheroo/base/test_file_datastore.py
+++ b/tests/switcheroo/base/test_file_datastore.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from hamcrest import assert_that, equal_to
+from tests.switcheroo.base import Person
+from tests.switcheroo.base.conftest import (
+    PersonGenerator,
+    PersonReader,
+    PersonPublisher,
+    PersonLocator,
+)
+from tests.switcheroo.base import HasFileMode
+from switcheroo.base.data_store import FileDataStore
+
+
+def test_publish(
+    file_datastore: FileDataStore,
+    person_generator: PersonGenerator,
+    read_person_from_file: PersonReader,
+):
+    generated_person = person_generator()
+    # Publish the person
+    file_datastore.publish(generated_person, generated_person.relative_loc)
+    # Read the person
+    person_stored = read_person_from_file(generated_person)
+    assert_that(person_stored, equal_to(generated_person))
+
+
+def test_retrieve(
+    file_datastore: FileDataStore,
+    person_generator: PersonGenerator,
+    publish_person_to_file: PersonPublisher,
+):
+    generated_person = person_generator()
+    # Publish the person
+    publish_person_to_file(generated_person)
+    # Read the person
+    person_stored = file_datastore.retrieve(generated_person.relative_loc, Person)
+    assert_that(person_stored, equal_to(generated_person))
+
+
+def test_can_specify_file_permissions(
+    file_datastore: FileDataStore,
+    person_generator: PersonGenerator,
+    person_locator: PersonLocator,
+):
+    file_datastore.register_file_permissions(
+        Person, FileDataStore.FilePermissions(0o755)
+    )
+    generated_person = person_generator()
+    # Publish the person
+    file_datastore.publish(generated_person, generated_person.relative_loc)
+    # Check file permissions
+    person_absolute_location = Path(person_locator(generated_person))
+    assert_that(person_absolute_location, HasFileMode(755))
+
+
+def test_default_file_permissions_are_777(
+    file_datastore: FileDataStore,
+    person_generator: PersonGenerator,
+    person_locator: PersonLocator,
+):
+    generated_person = person_generator()
+    # Publish the person
+    file_datastore.publish(generated_person, generated_person.relative_loc)
+    # Check file permissions
+    person_absolute_location = Path(person_locator(generated_person))
+    assert_that(person_absolute_location, HasFileMode(777))

--- a/tests/switcheroo/base/test_file_datastore.py
+++ b/tests/switcheroo/base/test_file_datastore.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from hamcrest import assert_that, equal_to
-from tests.switcheroo.base import Person
+from tests.switcheroo.base.resources import Person
 from tests.switcheroo.base.conftest import (
-    PersonGenerator,
     PersonReader,
     PersonPublisher,
     PersonLocator,
@@ -13,54 +12,50 @@ from switcheroo.base.data_store import FileDataStore
 
 def test_publish(
     file_datastore: FileDataStore,
-    person_generator: PersonGenerator,
+    rand_person: Person,
     read_person_from_file: PersonReader,
 ):
-    generated_person = person_generator()
     # Publish the person
-    file_datastore.publish(generated_person, generated_person.relative_loc)
+    file_datastore.publish(rand_person, rand_person.relative_loc)
     # Read the person
-    person_stored = read_person_from_file(generated_person)
-    assert_that(person_stored, equal_to(generated_person))
+    person_stored = read_person_from_file(rand_person)
+    assert_that(person_stored, equal_to(rand_person))
 
 
 def test_retrieve(
     file_datastore: FileDataStore,
-    person_generator: PersonGenerator,
+    rand_person: Person,
     publish_person_to_file: PersonPublisher,
 ):
-    generated_person = person_generator()
     # Publish the person
-    publish_person_to_file(generated_person)
+    publish_person_to_file(rand_person)
     # Read the person
-    person_stored = file_datastore.retrieve(generated_person.relative_loc, Person)
-    assert_that(person_stored, equal_to(generated_person))
+    person_stored = file_datastore.retrieve(rand_person.relative_loc, Person)
+    assert_that(person_stored, equal_to(rand_person))
 
 
 def test_can_specify_file_permissions(
     file_datastore: FileDataStore,
-    person_generator: PersonGenerator,
+    rand_person: Person,
     person_locator: PersonLocator,
 ):
     file_datastore.register_file_permissions(
         Person, FileDataStore.FilePermissions(0o755)
     )
-    generated_person = person_generator()
     # Publish the person
-    file_datastore.publish(generated_person, generated_person.relative_loc)
+    file_datastore.publish(rand_person, rand_person.relative_loc)
     # Check file permissions
-    person_absolute_location = Path(person_locator(generated_person))
+    person_absolute_location = Path(person_locator(rand_person))
     assert_that(person_absolute_location, HasFileMode(755))
 
 
 def test_default_file_permissions_are_777(
     file_datastore: FileDataStore,
-    person_generator: PersonGenerator,
+    rand_person: Person,
     person_locator: PersonLocator,
 ):
-    generated_person = person_generator()
     # Publish the person
-    file_datastore.publish(generated_person, generated_person.relative_loc)
+    file_datastore.publish(rand_person, rand_person.relative_loc)
     # Check file permissions
-    person_absolute_location = Path(person_locator(generated_person))
+    person_absolute_location = Path(person_locator(rand_person))
     assert_that(person_absolute_location, HasFileMode(777))

--- a/tests/switcheroo/base/test_s3_datastore.py
+++ b/tests/switcheroo/base/test_s3_datastore.py
@@ -1,0 +1,28 @@
+from hamcrest import assert_that, equal_to
+from tests.switcheroo.base.resources import Person
+from tests.switcheroo.base.conftest import PersonReader, PersonPublisher
+from switcheroo.base.data_store.s3 import S3DataStore
+
+
+def test_publish(
+    s3_datastore: S3DataStore,
+    rand_person: Person,
+    read_person_from_s3: PersonReader,
+):
+    # Publish the person
+    s3_datastore.publish(rand_person, rand_person.relative_loc)
+    # Read the person
+    person_stored = read_person_from_s3(rand_person)
+    assert_that(person_stored, equal_to(rand_person))
+
+
+def test_retrieve(
+    s3_datastore: S3DataStore,
+    rand_person: Person,
+    publish_person_to_s3: PersonPublisher,
+):
+    # Publish the person
+    publish_person_to_s3(rand_person)
+    # Read the person
+    person_stored = s3_datastore.retrieve(rand_person.relative_loc, Person)
+    assert_that(person_stored, equal_to(rand_person))


### PR DESCRIPTION
- Added tests for the base api
- fixtures for publishing/retrieving to be used when unit testing isolated components
- test publish/retrieve both types of datastores
- test file datastore permissions
- test ability to distinguish between modules/classes